### PR TITLE
Fix MarkDown syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,8 @@ If you discover any security related issues, please email :author_email instead 
 
 ## Credits
 
-- [:author_name][link-author]
-- [All Contributors][link-contributors]
+- [:author_name](link-author)
+- [All Contributors](link-contributors)
 
 ## License
 


### PR DESCRIPTION
Fix link syntax at [title][link] to be [title](link)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alariva/packager-skeleton/1)
<!-- Reviewable:end -->
